### PR TITLE
fixing header alignment

### DIFF
--- a/themes/rad/assets/sass/partials/_nav-bar.scss
+++ b/themes/rad/assets/sass/partials/_nav-bar.scss
@@ -20,6 +20,7 @@
     justify-self: flex-end;
 
     .header-btn {
+      padding-top: 1px;
       margin-left: 20px;
     }
 
@@ -58,6 +59,7 @@ nav {
     li {
       font-size: 16px;
       margin-left: 20px;
+      padding-top: 1px;
     }
   }
 


### PR DESCRIPTION
1px padding top added.

Goes from:
<img width="381" alt="Screenshot 2019-03-13 at 15 24 38" src="https://user-images.githubusercontent.com/2326909/54286431-2210f300-45a4-11e9-9142-f37b051cbda1.png">

to:
<img width="578" alt="Screenshot 2019-03-13 at 15 24 18" src="https://user-images.githubusercontent.com/2326909/54286447-2ccb8800-45a4-11e9-9b14-be2ea16c1f1c.png">

Especially fixes strange rendering in chrome on linux