### PR TITLE
Added mailchimp link + removed formspree

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,12 +40,9 @@
         <h1 class="headline druk">Locally sourced.</h1>
         <div class="email-signup">
           <p><strong>A peer-to-peer stack for building software together. Sound fun?</strong></p>
-          <form class="main-cta" action="https://formspree.io/xrgbwygl" method="POST" autocomplete="off">
-            <input type="email" name="email" placeholder="Enter your email here" required />
+          <form class="main-cta" action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
             <button type="submit">Sign me up</button>
-            <input type="hidden" name="_subject" value="Subscription" />
-            <input type="hidden" name="_format" value="plain" />
-            <input type="hidden" name="_next" value="/subscribed.html" />
           </form>
         </div>
       </section>
@@ -298,12 +295,9 @@
           <p>If you'd like to stay updated about product releases, project updates, and other announcements, hand us your e-mail and we'll keep you in the loop.</p>
           <br>
           <p>For updates, follow us on <a href="https://twitter.com/radicle_xyz" target="_blank"><span>Twitter</span></a>.</p>
-          <form action="https://formspree.io/xrgbwygl" autocomplete="off" method="POST">
-            <input type="email" name="email" placeholder="Enter your email here" required />
+          <form action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
             <button type="submit">Join</button>
-            <input type="hidden" name="_subject" value="Subscription" />
-            <input type="hidden" name="_format" value="plain" />
-            <input type="hidden" name="_next" value="/subscribed.html" />
           </form>
           <p class="small">Radicle is a project supported by The Radicle Foundation. <a href="mailto:hello@radicle.foundation"><span>Email us</span></a>.</p>
           <p class="small">Read about our <a href="/terms.html">Terms & Conditions</a> & <a href="/privacy.html">Privacy Policy</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
         <h1 class="headline druk">Locally sourced.</h1>
         <div class="email-signup">
           <p><strong>A peer-to-peer stack for building software together. Sound fun?</strong></p>
-          <form class="main-cta" action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+          <form class="main-cta" action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" autocomplete="off" class="validate" target="_blank" novalidate>
             <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
             <button type="submit">Sign me up</button>
           </form>
@@ -295,7 +295,7 @@
           <p>If you'd like to stay updated about product releases, project updates, and other announcements, hand us your e-mail and we'll keep you in the loop.</p>
           <br>
           <p>For updates, follow us on <a href="https://twitter.com/radicle_xyz" target="_blank"><span>Twitter</span></a>.</p>
-          <form action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+          <form action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" autocomplete="off" class="validate" target="_blank" novalidate autocomplete="off">
             <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
             <button type="submit">Join</button>
           </form>

--- a/pages/index.html.mustache
+++ b/pages/index.html.mustache
@@ -11,12 +11,9 @@
         <h1 class="headline druk">Locally sourced.</h1>
         <div class="email-signup">
           <p><strong>A peer-to-peer stack for building software together. Sound fun?</strong></p>
-          <form class="main-cta" action="https://formspree.io/xrgbwygl" method="POST" autocomplete="off">
-            <input type="email" name="email" placeholder="Enter your email here" required />
+          <form class="main-cta" action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" autocomplete="off" class="validate" target="_blank" novalidate>
+            <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
             <button type="submit">Sign me up</button>
-            <input type="hidden" name="_subject" value="Subscription" />
-            <input type="hidden" name="_format" value="plain" />
-            <input type="hidden" name="_next" value="/subscribed.html" />
           </form>
         </div>
       </section>

--- a/partials/footer.mustache
+++ b/partials/footer.mustache
@@ -6,12 +6,9 @@
       <p>If you'd like to stay updated about product releases, project updates, and other announcements, hand us your e-mail and we'll keep you in the loop.</p>
       <br>
       <p>For updates, follow us on <a href="https://twitter.com/radicle_xyz" target="_blank"><span>Twitter</span></a>.</p>
-      <form action="https://formspree.io/xrgbwygl" autocomplete="off" method="POST">
-        <input type="email" name="email" placeholder="Enter your email here" required />
+      <form action="https://xyz.us2.list-manage.com/subscribe/post?u=6c7bba7ab992717860dcec6eb&amp;id=f960345a90" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" autocomplete="off" class="validate" target="_blank" novalidate autocomplete="off">
+        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Enter your email here" required />
         <button type="submit">Join</button>
-        <input type="hidden" name="_subject" value="Subscription" />
-        <input type="hidden" name="_format" value="plain" />
-        <input type="hidden" name="_next" value="/subscribed.html" />
       </form>
       <p class="small">Radicle is a project supported by The Radicle Foundation. <a href="mailto:hello@radicle.foundation"><span>Email us</span></a>.</p>
       <p class="small">Read about our <a href="/terms.html">Terms & Conditions</a> & <a href="/privacy.html">Privacy Policy</a>.</p>


### PR DESCRIPTION
Embedded the mailchimp sign up form so we can keep the current flow (subscribe -> /subscribe.html). Right now the form redirects to radicle.xyz/subscribed.html - hopefully this is the right link, if not lmk and I'll change it in mailchimp flow.

Removed some formspree code that I don't think is necessary for mailchimp, but check it out and let me know.