### PR TITLE
Limit #features h1.druk font-size

### DIFF
--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -453,7 +453,6 @@ nav a:hover span {
 @media only screen and (max-width: 30rem) {
   #features h1.druk {
     font-size: 28vw;
-    line-height: 80%;
     padding-top: 5rem;
     margin-top: 6rem;
     white-space: normal;
@@ -469,7 +468,6 @@ nav a:hover span {
 @media only screen and (min-width: 90rem) {
   #features h1.druk {
     font-size: min(280px, 10.5vw);
-    line-height: 90%;
   }
 }
 

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -453,6 +453,7 @@ nav a:hover span {
 @media only screen and (max-width: 30rem) {
   #features h1.druk {
     font-size: 28vw;
+    line-height: 80%;
     padding-top: 5rem;
     margin-top: 6rem;
     white-space: normal;

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -469,6 +469,7 @@ nav a:hover span {
 @media only screen and (min-width: 90rem) {
   #features h1.druk {
     font-size: min(280px, 10.5vw);
+    line-height: 90%;
   }
 }
 

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -468,7 +468,7 @@ nav a:hover span {
 
 @media only screen and (min-width: 90rem) {
   #features h1.druk {
-    font-size: 10.5vw;
+    font-size: min(280px, 10.5vw);
   }
 }
 

--- a/docs/styles/typography.css
+++ b/docs/styles/typography.css
@@ -64,7 +64,6 @@ h3 {
   font-family: Druk X;
   font-weight: 400;
   letter-spacing: 0.03125rem;
-  line-height: 83%;
   padding-top: 3rem;
 }
 


### PR DESCRIPTION
It becomes too big on ultra-wide screens.

Currently: 
![Screenshot from 2020-11-30 11-25-14](https://user-images.githubusercontent.com/7075260/100600170-35786a80-3301-11eb-9ca4-237f7a86b16f.png)

With fix:

![fix](https://user-images.githubusercontent.com/7075260/100600532-b20b4900-3301-11eb-8e56-18c8b700efe0.png)

