### PR TITLE
Remove Default Text & Email Field Styles #177

### DIFF
--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -37,6 +37,13 @@ svg {
   color: var(--color-background);
 }
 
+input[type="email"],
+input[type="text"] {
+  /*Remove the default browser styles*/
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
 input[type="email"] {
   padding: 0 0 0 0.5rem;
   border-radius: 0.5rem;


### PR DESCRIPTION
With this merge, default Browser Styles for Input type Text and Email will be removed thereby, solving #177.