### PR TITLE
Disable Chromecast Functionality #205

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -40,7 +40,7 @@
     </header>
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted>
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted>
           <source type="video/mp4" src="/img/404.mp4">
         </video>
         <h1 class="headline druk">404</h1>

--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -38,7 +38,7 @@
     </nav>
   </header>
   <div class="content">
-    <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+    <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
       <source type="video/mp4" src="/img/download-flower.mp4">
     </video>
     <h1 class="headline druk">Try the beta</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
     </header>
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
           <source type="video/mp4" src="/img/header-flower.mp4">
         </video>
         <h1 class="headline druk">Free your code</h1>
@@ -59,7 +59,7 @@
 
       <section id="features">
         <img class="ui full-width" src="/img/ui/project-source-laptop.png" alt="Screenshot of a README file on the project page." />
-        <video class="features-gif gif" autoplay playsinline loop muted title="Animation of a cartoon typing very fast. Each of his fingers split into 3 smaller cyborg fingers allowing him to type even faster.">
+        <video disableRemotePlayback class="features-gif gif" autoplay playsinline loop muted title="Animation of a cartoon typing very fast. Each of his fingers split into 3 smaller cyborg fingers allowing him to type even faster.">
           <source type="video/mp4" src="/img/extending-hands.mp4">
         </video>
 
@@ -184,7 +184,7 @@
           <div class="subtitle-container">
             <h2>Built on open protocols, not platforms</h2>
           </div>
-          <video class="protocol-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="protocol-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/garden.mp4">
           </video>
           <div class="protocols">
@@ -229,7 +229,7 @@
       <section id="codelands">
         <div class="container">
           <h1 class="druk">Explore the codelands</h1>
-          <video class="codelands-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="codelands-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/blue-screen-of-death-walk.mp4">
           </video>
           <div class="two-column">
@@ -257,7 +257,7 @@
           <div class="subtitle-container">
             <h2>We see Radicle being the first open-source, community-led, self-sustaining network for software collaboration. Here's what we have in store:</h2>
           </div>
-          <video class="timeline-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="timeline-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/roadmap-flower.mp4">
           </video>
           <div class="timeline">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -41,7 +41,7 @@
     <div class="content">
       <section id="headline">
         <h1 class="headline druk privacy">Data &amp; Privacy Policy</h1>
-        <video class="headline-gif gif" autoplay playsinline loop muted title="A pink and orange flower blooming.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="A pink and orange flower blooming.">
           <source type="video/mp4" src="/img/privacy.mp4">
         </video>
       </section>

--- a/docs/subscribed.html
+++ b/docs/subscribed.html
@@ -40,7 +40,7 @@
     </header>
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
           <source type="video/mp4" src="/img/header-flower.mp4">
         </video>
         <h1 class="headline druk">Subscribed.</h1>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -41,7 +41,7 @@
     <div class="content">
       <section id="headline">
         <h1 class="headline druk">Terms of Use</h1>
-        <video class="headline-gif gif" autoplay playsinline loop muted title="A person made of flowers walking through grass.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="A person made of flowers walking through grass.">
           <source type="video/mp4" src="/img/terms.mp4">
         </video>
       </section>

--- a/pages/404.html.mustache
+++ b/pages/404.html.mustache
@@ -14,7 +14,7 @@
     {{> header }}
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted>
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted>
           <source type="video/mp4" src="/img/404.mp4">
         </video>
         <h1 class="headline druk">404</h1>

--- a/pages/downloads.html.mustache
+++ b/pages/downloads.html.mustache
@@ -12,7 +12,7 @@
 <body id="download">
   {{> header }}
   <div class="content">
-    <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+    <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
       <source type="video/mp4" src="/img/download-flower.mp4">
     </video>
     <h1 class="headline druk">Try the beta</h1>

--- a/pages/index.html.mustache
+++ b/pages/index.html.mustache
@@ -14,7 +14,7 @@
     {{> header }}
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
           <source type="video/mp4" src="/img/header-flower.mp4">
         </video>
         <h1 class="headline druk">Free your code</h1>
@@ -33,7 +33,7 @@
 
       <section id="features">
         <img class="ui full-width" src="/img/ui/project-source-laptop.png" alt="Screenshot of a README file on the project page." />
-        <video class="features-gif gif" autoplay playsinline loop muted title="Animation of a cartoon typing very fast. Each of his fingers split into 3 smaller cyborg fingers allowing him to type even faster.">
+        <video disableRemotePlayback class="features-gif gif" autoplay playsinline loop muted title="Animation of a cartoon typing very fast. Each of his fingers split into 3 smaller cyborg fingers allowing him to type even faster.">
           <source type="video/mp4" src="/img/extending-hands.mp4">
         </video>
 
@@ -105,7 +105,7 @@
           <div class="subtitle-container">
             <h2>Built on open protocols, not platforms</h2>
           </div>
-          <video class="protocol-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="protocol-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/garden.mp4">
           </video>
           <div class="protocols">
@@ -138,7 +138,7 @@
       <section id="codelands">
         <div class="container">
           <h1 class="druk">Explore the codelands</h1>
-          <video class="codelands-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="codelands-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/blue-screen-of-death-walk.mp4">
           </video>
           <div class="two-column">
@@ -166,7 +166,7 @@
           <div class="subtitle-container">
             <h2>We see Radicle being the first open-source, community-led, self-sustaining network for software collaboration. Here's what we have in store:</h2>
           </div>
-          <video class="timeline-gif gif" autoplay playsinline loop muted>
+          <video disableRemotePlayback class="timeline-gif gif" autoplay playsinline loop muted>
             <source type="video/mp4" src="/img/roadmap-flower.mp4">
           </video>
           <div class="timeline">

--- a/pages/privacy.html.mustache
+++ b/pages/privacy.html.mustache
@@ -15,7 +15,7 @@
     <div class="content">
       <section id="headline">
         <h1 class="headline druk privacy">Data &amp; Privacy Policy</h1>
-        <video class="headline-gif gif" autoplay playsinline loop muted title="A pink and orange flower blooming.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="A pink and orange flower blooming.">
           <source type="video/mp4" src="/img/privacy.mp4">
         </video>
       </section>

--- a/pages/subscribed.html.mustache
+++ b/pages/subscribed.html.mustache
@@ -14,7 +14,7 @@
     {{> header }}
     <div class="content">
       <section id="headline">
-        <video class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="Animation of a flower growing.">
           <source type="video/mp4" src="/img/header-flower.mp4">
         </video>
         <h1 class="headline druk">Subscribed.</h1>

--- a/pages/terms.html.mustache
+++ b/pages/terms.html.mustache
@@ -15,7 +15,7 @@
     <div class="content">
       <section id="headline">
         <h1 class="headline druk">Terms of Use</h1>
-        <video class="headline-gif gif" autoplay playsinline loop muted title="A person made of flowers walking through grass.">
+        <video disableRemotePlayback class="headline-gif gif" autoplay playsinline loop muted title="A person made of flowers walking through grass.">
           <source type="video/mp4" src="/img/terms.mp4">
         </video>
       </section>


### PR DESCRIPTION
# Description
This merge will **Disable Remote Playback** feature on Video Elements, thereby removing the Chromecast Button.

closes #205 

## Resources
 - [Google Developer Document](https://developers.google.com/web/updates/2015/11/presentation-api)
 - [W3C Page on Remote Playback API](https://w3c.github.io/remote-playback/#idl-def-htmlmediaelement-disableremoteplayback)