### PR TITLE
Brandon/update timeline

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -235,7 +235,7 @@
           <div class="two-column">
             <div class="two-column-item">
               <h3>Join the Community</h3>
-              <p>We're building everything publicly and open-source.</p>
+              <p>We’re building everything publicly and open-source.</p>
               <br>
               <br>
               <p>Join our <a target="_blank" href="https://radicle.community/"><span>community</span></a> or
@@ -262,23 +262,23 @@
           </video>
           <div class="timeline">
             <div class="line"></div>
-            <div class="timeline-item">
-              <p class="here">We're here</p>
+            <div class="timeline-item not-active">
+              <p class="not-here">not here</p>
               <div class="icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect width="24" height="24" rx="4" fill="#FF55FF"/>
-                <path d="M8.73429 6.67898C6.88485 6.67898 5.45304 7.87713 5.45304 9.67685V19.8636H7.20304V16.3736L7.27761 16.3438C7.84437 16.9304 8.54537 17.1143 9.24636 17.1143C11.0162 17.1143 12.3785 15.8466 12.3735 14.0866C12.3785 13.0426 11.8962 12.0682 10.9516 11.5362C11.6029 10.9794 11.941 10.169 11.936 9.39347C11.941 7.83239 10.5489 6.67898 8.73429 6.67898ZM8.22221 11.1136V12.3963H8.98287C9.9225 12.3963 10.6334 13.0575 10.6285 13.9673C10.6334 14.8423 9.96227 15.5682 8.90829 15.5682C7.84437 15.5682 7.20801 14.8274 7.20304 13.9474V9.76633C7.20801 8.83665 7.8742 8.27486 8.73429 8.27486C9.59437 8.27486 10.191 8.83665 10.186 9.61719C10.191 10.2734 9.75346 11.0092 8.70943 11.0092H8.22221V11.1136ZM17.7801 6.81818H16.0102C15.9704 7.26562 15.1452 8.43892 13.7432 8.43892V9.9304C14.8866 9.9304 15.6473 9.48793 15.8461 9.17472H15.9307V17H17.7801V6.81818Z" fill="#0E171F"/>
+                <rect x="9" y="9" width="6" height="6" fill="#28333D"/>
                 </svg>
               </div>
               <p class="date">Late 2020</p>
               <h3>Starting with the basics</h3>
               <p>The first release of our network and desktop client. Join the network and start securely hosting your code peer-to-peer.</p>
             </div>
-            <div class="timeline-item not-active">
-              <p class="not-here">not here</p>
+            <div class="timeline-item">
+              <p class="here">We’re here</p>
               <div class="icon">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect x="9" y="9" width="6" height="6" fill="#28333D"/>
+                <rect width="24" height="24" rx="4" fill="#FF55FF"/>
+                <path d="M8.73429 6.67898C6.88485 6.67898 5.45304 7.87713 5.45304 9.67685V19.8636H7.20304V16.3736L7.27761 16.3438C7.84437 16.9304 8.54537 17.1143 9.24636 17.1143C11.0162 17.1143 12.3785 15.8466 12.3735 14.0866C12.3785 13.0426 11.8962 12.0682 10.9516 11.5362C11.6029 10.9794 11.941 10.169 11.936 9.39347C11.941 7.83239 10.5489 6.67898 8.73429 6.67898ZM8.22221 11.1136V12.3963H8.98287C9.9225 12.3963 10.6334 13.0575 10.6285 13.9673C10.6334 14.8423 9.96227 15.5682 8.90829 15.5682C7.84437 15.5682 7.20801 14.8274 7.20304 13.9474V9.76633C7.20801 8.83665 7.8742 8.27486 8.73429 8.27486C9.59437 8.27486 10.191 8.83665 10.186 9.61719C10.191 10.2734 9.75346 11.0092 8.70943 11.0092H8.22221V11.1136ZM17.7801 6.81818H16.0102C15.9704 7.26562 15.1452 8.43892 13.7432 8.43892V9.9304C14.8866 9.9304 15.6473 9.48793 15.8461 9.17472H15.9307V17H17.7801V6.81818Z" fill="#0E171F"/>
                 </svg>
               </div>
               <p class="date">Early 2021</p>

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -1216,6 +1216,10 @@ nav a.active span {
   opacity: 0;
 }
 
+.not-active .icon svg {
+  margin-left: -9px;
+}
+
 .date {
   color: var(--color-foreground);
 }

--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -1217,7 +1217,7 @@ nav a.active span {
 }
 
 .not-active .icon svg {
-  margin-left: -9px;
+  margin-left: -0.5625rem;
 }
 
 .date {

--- a/pages/index.html.mustache
+++ b/pages/index.html.mustache
@@ -144,7 +144,7 @@
           <div class="two-column">
             <div class="two-column-item">
               <h3>Join the Community</h3>
-              <p>We're building everything publicly and open-source.</p>
+              <p>We’re building everything publicly and open-source.</p>
               <br>
               <br>
               <p>Join our <a target="_blank" href="https://radicle.community/"><span>community</span></a> or
@@ -171,19 +171,19 @@
           </video>
           <div class="timeline">
             <div class="line"></div>
-            <div class="timeline-item">
-              <p class="here">We're here</p>
+            <div class="timeline-item not-active">
+              <p class="not-here">not here</p>
               <div class="icon">
-                {{> svg-here }}
+                {{> svg-date-square }}
               </div>
               <p class="date">Late 2020</p>
               <h3>Starting with the basics</h3>
               <p>The first release of our network and desktop client. Join the network and start securely hosting your code peer-to-peer.</p>
             </div>
-            <div class="timeline-item not-active">
-              <p class="not-here">not here</p>
+            <div class="timeline-item">
+              <p class="here">We’re here</p>
               <div class="icon">
-                {{> svg-date-square }}
+                {{> svg-here }}
               </div>
               <p class="date">Early 2021</p>
               <h3>Going further <br />with Ethereum</h3>


### PR DESCRIPTION
- Moved the active timeline square to 2021. 
- Updated the quote characters to be curly quotes
- Adjusted the inactive squares so that they align with the text and the ends of the gradient line.

closes #215 

![image](https://user-images.githubusercontent.com/4406983/110478305-7f34d600-80e4-11eb-926e-ccfbac117689.png)
