### PR TITLE
Change blog link to go to radicle.blog

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/announcing-the-seeders-program.html
+++ b/docs/blog/announcing-the-seeders-program.html
@@ -31,7 +31,7 @@
        </svg>
      </a>
      <nav>
-       <a href="/blog"><span>Blog</span></a>
+       <a href="http://radicle.blog"><span>Blog</span></a>
        <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
        <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
        <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/collaborating-on-radicle.html
+++ b/docs/blog/collaborating-on-radicle.html
@@ -31,7 +31,7 @@
        </svg>
      </a>
      <nav>
-       <a href="/blog"><span>Blog</span></a>
+       <a href="http://radicle.blog"><span>Blog</span></a>
        <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
        <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
        <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/integrating-with-ethereum.html
+++ b/docs/blog/integrating-with-ethereum.html
@@ -31,7 +31,7 @@
        </svg>
      </a>
      <nav>
-       <a href="/blog"><span>Blog</span></a>
+       <a href="http://radicle.blog"><span>Blog</span></a>
        <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
        <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
        <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/introducing-rad.html
+++ b/docs/blog/introducing-rad.html
@@ -31,7 +31,7 @@
        </svg>
      </a>
      <nav>
-       <a href="/blog"><span>Blog</span></a>
+       <a href="http://radicle.blog"><span>Blog</span></a>
        <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
        <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
        <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/radicle-link.html
+++ b/docs/blog/radicle-link.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/blog/towards-decentralized-code-collaboration.html
+++ b/docs/blog/towards-decentralized-code-collaboration.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -30,7 +30,7 @@
       </svg>
     </a>
     <nav>
-      <a href="/blog"><span>Blog</span></a>
+      <a href="http://radicle.blog"><span>Blog</span></a>
       <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
       <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
       <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/subscribed.html
+++ b/docs/subscribed.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -31,7 +31,7 @@
         </svg>
       </a>
       <nav>
-        <a href="/blog"><span>Blog</span></a>
+        <a href="http://radicle.blog"><span>Blog</span></a>
         <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
         <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
         <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>

--- a/partials/header.mustache
+++ b/partials/header.mustache
@@ -3,7 +3,7 @@
     {{> logo }}
   </a>
   <nav>
-    <a href="/blog"><span>Blog</span></a>
+    <a href="http://radicle.blog"><span>Blog</span></a>
     <a href="https://docs.radicle.xyz" target="_blank"><span>Docs</span> ↗</a>
     <a href="https://radicle.community" target="_blank"><span>Community</span> ↗</a>
     <a href="https://github.com/radicle-dev" target="_blank"><span>Code</span> ↗</a>


### PR DESCRIPTION
I don't think we should do this, @xla just mentioned it, so I'm just putting it here if it's something we want.

I think we should deprecate radicle.blog as it was just a temporary fix and maintaining two identical websites is BAD!